### PR TITLE
Add example Chrome extension for ASIN data injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Test of a chrome extension
+
+## Usage
+1. Publish your Google Sheet as CSV or provide a SharePoint Excel link. Update `SHEET_URL` in `content-script.js` with that URL.
+2. Load the extension in Chrome:
+   - Open `chrome://extensions` and enable Developer mode.
+   - Click **Load unpacked** and select this folder.
+3. Navigate to an Amazon product page. If the ASIN exists in your sheet, the custom data block will appear at the top of the page.
+
+The sheet should have a header row with at least an `ASIN` column.

--- a/content-script.js
+++ b/content-script.js
@@ -1,0 +1,55 @@
+(async function() {
+  const SHEET_URL = 'https://docs.google.com/spreadsheets/d/YOUR_SHEET_ID/export?format=csv';
+  const ASIN = extractASIN();
+  if (!ASIN) return;
+
+  try {
+    const data = await getData(SHEET_URL);
+    const match = data.find(row => row.ASIN === ASIN);
+    if (match) {
+      injectInfo(match, ASIN);
+    }
+  } catch (err) {
+    console.error('Failed to load ASIN data', err);
+  }
+
+  function extractASIN() {
+    const urlMatch = location.pathname.match(/\/dp\/([A-Z0-9]{10})/i);
+    if (urlMatch) return urlMatch[1];
+    const asinElement = document.getElementById('ASIN');
+    return asinElement ? asinElement.value : null;
+  }
+
+  async function getData(url) {
+    const cached = await chrome.storage.local.get('asinData');
+    if (cached.asinData) return cached.asinData;
+
+    const resp = await fetch(url);
+    const text = await resp.text();
+    const rows = text.trim().split(/\r?\n/);
+    const headers = rows.shift().split(',');
+    const data = rows.map(line => {
+      const values = line.split(',');
+      const obj = {};
+      headers.forEach((h,i)=> obj[h.trim()] = values[i].trim());
+      return obj;
+    });
+    await chrome.storage.local.set({ asinData: data });
+    return data;
+  }
+
+  function injectInfo(info, asin) {
+    const container = document.createElement('div');
+    container.style.border = '2px solid #f90';
+    container.style.padding = '10px';
+    container.style.margin = '10px 0';
+    container.style.background = '#fff8e1';
+    container.innerHTML = `<strong>Custom Data for ${asin}</strong><br>${JSON.stringify(info)}`;
+    const target = document.querySelector('#dp');
+    if (target) {
+      target.prepend(container);
+    } else {
+      document.body.prepend(container);
+    }
+  }
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Amazon ASIN Data Injector",
+  "description": "Inject custom data into Amazon listings from a sheet.",
+  "version": "1.0",
+  "content_scripts": [
+    {
+      "matches": ["https://www.amazon.com/*"],
+      "js": ["content-script.js"]
+    }
+  ],
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://docs.google.com/*",
+    "https://*.sharepoint.com/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- add `manifest.json` for Chrome extension setup
- create `content-script.js` to fetch dataset and inject info
- update `README` with instructions for loading the extension

## Testing
- `node -c content-script.js`

------
https://chatgpt.com/codex/tasks/task_b_68405902e2448327a83a259fd4c3efd0